### PR TITLE
Fixed parameter when calling migrate_static_registration.

### DIFF
--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -104,8 +104,8 @@ function migrate_default_content_migrate_api() {
 function migrate_default_content_flush_caches() {
   $defined_migrations = migrate_default_content_fetch_migrations();
   // Register defined migrations.
-  if (!empty($defined_migrations['migrations'])) {
-    migrate_static_registration(array_keys($defined_migrations['migrations']));
+  if (!empty($defined_migrations)) {
+    migrate_static_registration(array_keys($defined_migrations));
   }
 }
 


### PR DESCRIPTION
On #7, I made a mistake when refactoring: $defined_migration now contains all the migrations on root, not inside a key element called "migrations". I fixed that here.
