### PR TITLE
Reorder on preprocessMapp to prevent losing source_migration in some cases

### DIFF
--- a/includes/migrate_default_content.migrate.base.inc
+++ b/includes/migrate_default_content.migrate.base.inc
@@ -106,6 +106,13 @@ abstract class defaultBaseMigration extends Migration {
       $migrate->separator($value['separator']);
     }
 
+    if (!empty($value['source_migration'])) {
+      if (empty($migrate) || !$migrate instanceof MigrateFieldMapping) {
+        $migrate = $this->addFieldMapping($key, $key, FALSE);
+      }
+      $migrate->sourceMigration(array($value['source_migration']));
+    }
+
     if (!empty($value['components']) && is_array($value['components'])) {
       foreach ($value['components'] as $name => $component) {
         if ($name == 'source_dir') {
@@ -116,12 +123,6 @@ abstract class defaultBaseMigration extends Migration {
       }
     }
 
-    if (!empty($value['source_migration'])) {
-      if (empty($migrate) || !$migrate instanceof MigrateFieldMapping) {
-        $migrate = $this->addFieldMapping($key, $key, FALSE);
-      }
-      $migrate->sourceMigration(array($value['source_migration']));
-    }
   }
 
 }


### PR DESCRIPTION
 Moved source_migration processing on top of components in preprocessMapping function, to prevent source_migration getting lost when both components and source_migration elements are present on a mapping.
