### PR TITLE
[#2824916] Give support for entity_reference_revisions field type

### DIFF
--- a/example_default_content/block_content.rotating_banner.csv
+++ b/example_default_content/block_content.rotating_banner.csv
@@ -1,0 +1,2 @@
+info,uid,field_slide,uuid
+Main Rotating Banner,demo,"[\"Slide 1\",\"Slide 2\"]",d9276d33-4bd4-492d-9631-b92c9bc8bfbc

--- a/example_default_content/paragraph.rotating_banner_item.csv
+++ b/example_default_content/paragraph.rotating_banner_item.csv
@@ -1,0 +1,3 @@
+field_title,field_caption,field_imageTarget_id,field_imageAlt,parent_id,parent_type,parent_field_name
+Slide 1,Caption 1,demo.jpg,Demo,1,block_content,field_slide
+Slide 2,Caption 2,magic.png,Magic,1,block_content,field_slide

--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -115,6 +115,7 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
       if ($field_definition) {
         switch ($field_definition->getType()) {
           case 'entity_reference':
+          case 'entity_reference_revisions':
             $settings = $field_definition->getItemDefinition()->getSettings();
             $target_entity_type = $settings['target_type'];
 


### PR DESCRIPTION
Hello,

I was trying to create paragraphs items using this module, but I was not able, given that entity_reference_revisions field type was not supported.

Adding the change below, it's possible to import paragraph items.

Thanks

PS: RElated to d.o issue https://www.drupal.org/node/2824916