### PR TITLE
Add support for migrating entity revisions

### DIFF
--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -24,11 +24,6 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
       if ($file != "." && $file != "..") {
         $language = '';
         $entity_type = $fileparts[0];
-        $is_revision = FALSE;
-        if (substr($entity_type, -9) === '_revision') {
-          $entity_type = substr($entity_type, 0, -9);
-          $is_revision = TRUE;
-        }
         $bundle = $fileparts[1];
         // If the file is a translation save the language that is informed in
         // the filename before the file extension.
@@ -69,8 +64,14 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
             'type' => $type,
             'filename' => $file,
             'language' => $language,
-            'is_revision' => $is_revision,
+            'is_revision' => FALSE,
           ];
+
+          if (\Drupal::entityTypeManager()->getDefinition($entity_type)->isRevisionable()) {
+            $id_revision = empty($language) ? 'migrate_default_content_' . $entity_type . '_revision_' . $bundle : 'migrate_default_content_' . $entity_type . '_revision_' . $bundle . '_' . $language;
+            $migrations[$id_revision] = $migrations[$id];
+            $migrations[$id_revision]['is_revision'] = TRUE;
+          }
 
         }
       }
@@ -99,6 +100,7 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
     // Assume the key is the first field of the csv.
     $key = trim(reset($headers));
 
+    $destination = $migration['is_revision'] ? 'entity_revision' : 'entity';
     $migration_plugin = [
       'id' => $id,
       'migration_group' => 'migrate_default_content',
@@ -106,7 +108,7 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
       'class' => '\Drupal\migrate\Plugin\Migration',
       'status' => 1,
       'destination' => [
-        'plugin' => 'entity:' . $migration['entity_type'],
+        'plugin' => $destination . ':' . $migration['entity_type'],
         'translations' => FALSE,
       ],
     ];
@@ -255,21 +257,6 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
       $migration_plugin = array_merge_recursive($migration_plugin, $override);
     }
     $definitions[$id] = $migration_plugin;
-
-    if ($migration['is_revision']) {
-      $id_key = \Drupal::service('entity_type.manager')->getDefinition($migration['entity_type'])->getKey('id');
-      $revision_migration_plugin = $migration_plugin;
-      $revision_migration_plugin['id'] = str_replace($migration['entity_type'], $migration['entity_type'] . '_revision', $id);
-      $revision_migration_plugin['label'] = $revision_migration_plugin['id'];
-      $revision_migration_plugin['destination']['plugin'] = 'entity_revision:' . $migration['entity_type'];
-      $revision_migration_plugin['process'][$id_key] = [
-        'plugin' => 'migration',
-        'migration' => $id,
-        'source' => $key,
-      ];
-
-      $definitions[$revision_migration_plugin['id']] = $revision_migration_plugin;
-    }
   }
   if (isset($migrations['migrate_default_content_file'])) {
     $definitions['migrate_default_content_file'] = [

--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -24,6 +24,11 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
       if ($file != "." && $file != "..") {
         $language = '';
         $entity_type = $fileparts[0];
+        $is_revision = FALSE;
+        if (substr($entity_type, -9) === '_revision') {
+          $entity_type = substr($entity_type, 0, -9);
+          $is_revision = TRUE;
+        }
         $bundle = $fileparts[1];
         // If the file is a translation save the language that is informed in
         // the filename before the file extension.
@@ -64,6 +69,7 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
             'type' => $type,
             'filename' => $file,
             'language' => $language,
+            'is_revision' => $is_revision,
           ];
 
         }
@@ -245,6 +251,21 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
       $migration_plugin = array_merge_recursive($migration_plugin, $override);
     }
     $definitions[$id] = $migration_plugin;
+
+    if ($migration['is_revision']) {
+      $id_key = \Drupal::service('entity_type.manager')->getDefinition($migration['entity_type'])->getKey('id');
+      $revision_migration_plugin = $migration_plugin;
+      $revision_migration_plugin['id'] = str_replace($migration['entity_type'], $migration['entity_type'] . '_revision', $id);
+      $revision_migration_plugin['label'] = $revision_migration_plugin['id'];
+      $revision_migration_plugin['destination']['plugin'] = 'entity_revision:' . $migration['entity_type'];
+      $revision_migration_plugin['process'][$id_key] = [
+        'plugin' => 'migration',
+        'migration' => $id,
+        'source' => $key,
+      ];
+
+      $definitions[$revision_migration_plugin['id']] = $revision_migration_plugin;
+    }
   }
   if (isset($migrations['migrate_default_content_file'])) {
     $definitions['migrate_default_content_file'] = [

--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -203,9 +203,13 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
         $field_definition = \Drupal::service('entity_field.manager')->getFieldDefinitions($migration['entity_type'], $migration['bundle'])[$field];
         // Handle special field types.
         if ($field_definition) {
+          $suffix = '';
           switch ($field_definition->getType()) {
-            case 'entity_reference':
             case 'entity_reference_revisions':
+              $suffix = '_revision';
+              // Intentional fall-through.
+
+            case 'entity_reference':
               $settings = $field_definition->getItemDefinition()->getSettings();
               $target_entity_type = $settings['target_type'];
 
@@ -217,13 +221,13 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
               if (!empty($extra)) {
                 // Add all posible referenceable bundles.
                 foreach ($extra as $target_bundle) {
-                  $target_id = 'migrate_default_content_' . $target_entity_type . '_' . $target_bundle;
+                  $target_id = 'migrate_default_content_' . $target_entity_type . $suffix . '_' . $target_bundle;
                   $migration_plugin = migrate_default_content_add_target_migration($migrations, $migration_plugin, $dest_field, $target_id);
                 }
               }
               // Assume is a entity with only one bundle. e.g. user.
               else {
-                $target_id = 'migrate_default_content_' . $target_entity_type . '_' . $target_entity_type;
+                $target_id = 'migrate_default_content_' . $target_entity_type . $suffix . '_' . $target_entity_type;
                 $migration_plugin = migrate_default_content_add_target_migration($migrations, $migration_plugin, $dest_field, $target_id);
               }
 
@@ -323,7 +327,7 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
 function migrate_default_content_add_target_migration($migrations, $migration_plugin, $dest_field, $target_id) {
   if (isset($migrations[$target_id])) {
     $dest_subfield = explode('/', $dest_field);
-    if (isset($dest_subfield[1]) && $dest_subfield[1] != 'target_id') {
+    if (isset($dest_subfield[1]) && ($dest_subfield[1] != 'target_id') && ($dest_subfield[1] != 'target_revision_id')) {
       return $migration_plugin;
     }
     // We don't need a source because only the first process plugin in


### PR DESCRIPTION
I'm using entity reference revisions and I don't want to explicitly reference ID and revision ID in the content. So just like for the `target_id` entity references this module currently sets up a migration I want to set up a similar migration for the `target_revision_id` of entity reference revisions. However, for that to work the module first has to provide such migrations in the first place. That is what this patch does.

For revisionable entity types, a `$entity_type_id . '_revision'` migration is automatically provided on top of the non-revision one. The revision one uses the first one as the source for the ID. That allows using the second migration as source for the `target_revision_id` property.

It also sets up this migration for entity reference fields.

Example usage:
```yaml
# ../default_content/node.article.yml
-
  title: 'Example page'
  field_paragraphsTarget_revision_id: 77152a7c-e331-43ea-a927-6fd687831368

# ../default_content/paragraph.text.yml
-
  uuid: 77152a7c-e331-43ea-a927-6fd687831368
  field_textValue: 'Example paragraph text'
  field_textFormat: basic_html
```

Edit: fix some unnecessary nesting in example yml
Edit2: Actually describe behavior correctly. (I had to change this around a bunch of times before it worked, sorry...)
Edit3: Updated again to match new behavior.