### PR TITLE
Add support for file entities migration.

### DIFF
--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -235,6 +235,22 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
           }
         }
       }
+
+      if ($field === 'uri' && $migration['entity_type'] === 'file') {
+        unset($migration_plugin['process']['uri']);
+      }
+    }
+
+    if ($migration['entity_type'] === 'file') {
+      $migration_plugin['process']['uri'] = [
+        [
+          'plugin' => 'file_copy',
+          'source' => [
+            '@source_full_path',
+            '@destination_full_uri',
+          ],
+        ],
+      ];
     }
 
     // Look up for an override yml file.
@@ -246,6 +262,7 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
     }
     $definitions[$id] = $migration_plugin;
   }
+
   if (isset($migrations['migrate_default_content_file'])) {
     $definitions['migrate_default_content_file'] = [
       'id' => 'migrate_default_content_file',


### PR DESCRIPTION
Motivation: I want to migrate default images for fields. Therefore I need to set their uuid during migration and I want to store files outside my public:// directory, so I can commit them. All fields are set using get process plugin, so files are not copied over to destination directory.

Solution:
1) provide way, how to specify uuid for migrate_default_content_file migration.
or
2) add condition(s) for file entity migration, where process for uri field will be defined.

My patch is solving this issue the second way.