### PR TITLE
Add entity reference revisions support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The name of the files follows a standard: ENTITY_TYPE.BUNDLE.FILE_TYPE
 like user.user.csv or node.article.yml
 
 You can find examples for most entity types in the
-example_default_content folder.
+example_default_content_csv and example_default_content_yml folders.
 
 Any field with the password data type will be hashed automatically.
 
@@ -26,6 +26,9 @@ should reference you can specify it in the name of the field like this
 
 title,uid,body,field_related:article
 Hello world,demo,Body,My article
+
+Entity reference revision fields (mainly to give support to paragraphs) behave
+roughly the same.
 
 # Files
 

--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -348,7 +348,7 @@ function migrate_default_content_add_target_migration(
 ) {
   if (isset($migrations[$target_id])) {
     $dest_subfield = explode('/', $dest_field);
-    if (isset($dest_subfield[1]) && ($dest_subfield[1] != 'target_id') && ($dest_subfield[1] != 'target_revision_id')) {
+    if (isset($dest_subfield[1]) && $dest_subfield[1] != 'target_id' && $dest_subfield[1] != 'target_revision_id') {
       return $migration_plugin;
     }
     // We don't need a source because only the first process plugin in

--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -211,13 +211,29 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
                 // Add all posible referenceable bundles.
                 foreach ($extra as $target_bundle) {
                   $target_id = 'migrate_default_content_' . $target_entity_type . '_' . $target_bundle;
-                  $migration_plugin = migrate_default_content_add_target_migration($migrations, $migration_plugin, $dest_field, $target_id);
+                  $migration_plugin = migrate_default_content_add_target_migration(
+                    $migrations,
+                    $migration_plugin,
+                    $dest_field,
+                    $target_id,
+                    $target_entity_type,
+                    $field_definition->getType()
+                  );
                 }
               }
-              // Assume is a entity with only one bundle. e.g. user.
+              // Assume is an entity with only one bundle. e.g. user.
+              // TODO: do not assume. it might be because all bundles are
+              // allowed.
               else {
                 $target_id = 'migrate_default_content_' . $target_entity_type . '_' . $target_entity_type;
-                $migration_plugin = migrate_default_content_add_target_migration($migrations, $migration_plugin, $dest_field, $target_id);
+                $migration_plugin = migrate_default_content_add_target_migration(
+                  $migrations,
+                  $migration_plugin,
+                  $dest_field,
+                  $target_id,
+                  $target_entity_type,
+                  $field_definition->getType()
+                );
               }
 
               break;
@@ -225,7 +241,13 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
             case 'file':
             case 'image':
               $target_id = 'migrate_default_content_file';
-              $migration_plugin = migrate_default_content_add_target_migration($migrations, $migration_plugin, $dest_field, $target_id);
+              $migration_plugin = migrate_default_content_add_target_migration(
+                $migrations,
+                $migration_plugin,
+                $dest_field,
+                $target_id,
+                'file'
+              );
 
               break;
 
@@ -316,10 +338,17 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
 /**
  * Add a migration to the process pipeline with its dependency.
  */
-function migrate_default_content_add_target_migration($migrations, $migration_plugin, $dest_field, $target_id) {
+function migrate_default_content_add_target_migration(
+  $migrations,
+  $migration_plugin,
+  $dest_field,
+  $target_id,
+  $target_entity_type,
+  $field_type = 'entity_reference'
+) {
   if (isset($migrations[$target_id])) {
     $dest_subfield = explode('/', $dest_field);
-    if (isset($dest_subfield[1]) && $dest_subfield[1] != 'target_id') {
+    if (isset($dest_subfield[1]) && ($dest_subfield[1] != 'target_id') && ($dest_subfield[1] != 'target_revision_id')) {
       return $migration_plugin;
     }
     // We don't need a source because only the first process plugin in
@@ -329,6 +358,13 @@ function migrate_default_content_add_target_migration($migrations, $migration_pl
       'migration' => $target_id,
       'no_stub' => TRUE,
     ];
+    // Add only for entity_reference revisions.
+    if ($field_type === 'entity_reference_revisions') {
+      $migration_plugin['process'][$dest_field][] = [
+        'plugin' => 'content_id_to_revision_reference',
+        'target_entity_type' => $target_entity_type,
+      ];
+    }
     // Avoid dependencies on itself.
     if ($target_id != $migration_plugin['id']) {
       $migration_plugin['migration_dependencies']['required'][] = $target_id;

--- a/src/Plugin/migrate/process/ContentIdToRevisionReference.php
+++ b/src/Plugin/migrate/process/ContentIdToRevisionReference.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\migrate_default_content\Plugin\migrate\process;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Transform a content id to what the entity revisions field expects.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "content_id_to_revision_reference"
+ * )
+ */
+class ContentIdToRevisionReference extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, EntityTypeManagerInterface $entityTypeManager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->migration = $migration;
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $migration,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    // Load the entity revision id.
+    $target_revision_id = $this
+      ->entityTypeManager
+      ->getStorage($this->configuration['target_entity_type'])
+      ->load($value)
+      ->getRevisionId();
+    // Build and array with the structure that entity reference revisions
+    // is expecting.
+    return [
+      'target_id' => $value,
+      'target_revision_id' => $target_revision_id,
+    ];
+  }
+
+}

--- a/src/Plugin/migrate/process/ContentIdToRevisionReference.php
+++ b/src/Plugin/migrate/process/ContentIdToRevisionReference.php
@@ -58,7 +58,7 @@ class ContentIdToRevisionReference extends ProcessPluginBase implements Containe
       ->getStorage($this->configuration['target_entity_type'])
       ->load($value)
       ->getRevisionId();
-    // Build and array with the structure that entity reference revisions
+    // Build an array with the structure that entity reference revisions
     // is expecting.
     return [
       'target_id' => $value,


### PR DESCRIPTION
Rethinking of https://github.com/Ymbra/migrate_default_content/pull/30

The difference is that we don't create extra migrations for revisions but we build the structure that entity_reference_revisons expects.