### PR TITLE
Remove migrate_source_csv from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "source": "https://github.com/ymbra/migrate_default_content"
   },
   "require": {
-    "drupal/core": "~8.1",
-    "drupal/migrate_source_csv": "~8.0"
+    "drupal/core": "~8.3"
   }
 }


### PR DESCRIPTION
It is no longer required in the info.yml, so shouldn't be required in composer.json either. Currently this module cannot be installed via Composer because the version constraint should be ~2.0, not ~8.0.

Since I'm already touching this, also updating the core dependency to Drupal ~8.3, since that's the only supported version ATM. (Not really sure why that dependency is there in the first place, though.)