### PR TITLE
Read fields to migrate from all the entities, not only the first one.

### DIFF
--- a/src/Plugin/MigrateDefaultContent/Source/Yaml.php
+++ b/src/Plugin/MigrateDefaultContent/Source/Yaml.php
@@ -25,9 +25,12 @@ class Yaml extends BaseSourcePlugin {
     parent::__construct($configuration);
 
     // Initialize header.
+    $this->header = [];
     $parser = new Parser();
     $data = $parser->parse(file_get_contents($this->getFullPathFile()));
-    $this->header = array_keys($data[0]);
+    foreach ($data as $item) {
+      $this->header = array_merge($this->header, array_diff(array_keys($item), $this->header));
+    }
   }
 
   /**


### PR DESCRIPTION
When migrating entities using Yaml format, only the fields declared in the first one are imported.
Here is a example:

> -
>   title: 'My title'
> 
> -
>   title: 'My new title'
>   body: 'It is not migrated'

That's because Yaml Source plugin only reads the 1st element. In this patch we are proposing to read all the elements and get the different fields from all the elements to avoid that behavior.

Thank you.
