### PR TITLE
migrate_default_content_generic_field_type cleanup

### DIFF
--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -306,10 +306,10 @@ function migrate_default_content_migration_plugins_alter(&$definitions) {
  */
 function migrate_default_content_generic_field_type(FieldDefinitionInterface $field_definition) {
   $field_type = \Drupal::service('plugin.manager.field.field_type')->getDefinition($field_definition->getType());
-  if ($field_type['class'] === FileItem::class || is_subclass_of($field_type['class'], FileItem::class)) {
+  if (is_a($field_type['class'], FileItem::class)) {
     $type = 'file';
   }
-  elseif ($field_type['class'] === EntityReferenceItem::class || is_subclass_of($field_type['class'], EntityReferenceItem::class)) {
+  elseif (is_a($field_type['class'], EntityReferenceItem::class)) {
     $type = 'entity_reference';
   }
   else {


### PR DESCRIPTION
I ran this issue I introduced in the past (sorry for not testing it in a more extensive way) today and I did this modification locally.
Then I found you already fixed it, however, I believe that using just `is_a()` is a cleaner approach than having the 2 conditionals.

Sorry again for introducing the bug and thank you again for this module!