### PR TITLE
Update Yaml source to match Interface definition

### DIFF
--- a/src/Plugin/migrate/source/Yaml.php
+++ b/src/Plugin/migrate/source/Yaml.php
@@ -100,7 +100,7 @@ class Yaml extends SourcePluginBase {
   /**
    * {@inheritdoc}
    */
-  public function count() {
+  public function count($refresh = FALSE) {
     return count($this->dataRows);
   }
 


### PR DESCRIPTION
We are having some errors because the source plugin does not match the exact interface definition.
```
PHP Fatal error:  Declaration of Drupal\migrate_default_content\Plugin\migrate\source\Yaml::count() must be compatible with Drupal\migrate\Plugin\migrate\source\SourcePluginBase::count($refresh = false) in /var/www/midwife-staging/web/modules/contrib/migrate_default_content/src/Plugin/migrate/source/Yaml.php on line 24
```

This happened after upgrading one of our projects to PHP 7.2

Thank you!