### PR TITLE
Allow to implement Yaml array syntax when cardinality is 1

### DIFF
--- a/migrate_default_content.module
+++ b/migrate_default_content.module
@@ -336,7 +336,13 @@ function migrate_default_content_add_target_migration(
     if (isset($dest_subfield[1]) && $dest_subfield[1] != 'target_id' && $dest_subfield[1] != 'target_revision_id') {
       return $migration_plugin;
     }
-    if ($multiple) {
+
+    // If we are handling references as nested values, use the iterator pattern.
+    if (!isset($dest_subfield[1])) {
+      // Add the array wrapper process to single value fields.
+      if (!$multiple) {
+        $migration_plugin['process'][$dest_field][] = ['plugin' => 'array_wrapper'];
+      }
 
       // Assume all the target migrations are configured the same with the same
       // first field.

--- a/src/Plugin/migrate/process/ArrayWrapper.php
+++ b/src/Plugin/migrate/process/ArrayWrapper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\migrate_default_content\Plugin\migrate\process;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Password\PasswordInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Iterator requires an array, so wraps content to be iterable..
+ *
+ * @MigrateProcessPlugin(
+ *   id = "array_wrapper",
+ *   handle_multiples = TRUE
+ * )
+ */
+class ArrayWrapper extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    // Wraps value into an array.
+    return isset($value) ? [$value] : $value;
+  }
+
+}


### PR DESCRIPTION
When creating entity reference fields with more than one extra values, like image alt or title, it is not possible to use the array based architecture like this:
```
field_image:
  filename: magic.png
  alt: Alt text
```
MDC now forces us to use the camelCase format to handle single dependencies like that one:
```
field_imageTarget_id: magic.png
field_imageAlt: Alt text
```
However, when cardinality > 1, we can use this format safely:
```
field_image:
  -
    filename: magic.png
    alt: Alt text
  -
    filename: magic2.png
    alt: Alt text
```

Would be great to allow to use the array syntax even if the cardinality is 1, because I believe it is more readable.

This patch is a first iteration, that will break other ways like CSV or the same Yaml camelCase structure. So please, take a look and share your thoughts.

Thank you.
