### PR TITLE
Fix error in target migration declaration that leads to circular dependencies

### DIFF
--- a/src/MigrationGenerator.php
+++ b/src/MigrationGenerator.php
@@ -456,7 +456,7 @@ class MigrationGenerator implements MigrationGeneratorInterface {
 
       // Avoid dependencies on itself.
       foreach ($target_ids as $target_id) {
-        if ($target_id != $migration_plugin['id']) {
+        if ($target_id != $migration_plugin['label']) {
           $migration_plugin['migration_dependencies']['required'][] = $target_id;
         }
       }


### PR DESCRIPTION
While migrating the migration generator to a new service, I forgot to refactor this line, so we are creating circular dependencies that break the migration process.
Using the right array value solves the problem