### PR TITLE
Fix error in the migration ID definition

### DIFF
--- a/src/MigrationGenerator.php
+++ b/src/MigrationGenerator.php
@@ -219,7 +219,7 @@ class MigrationGenerator implements MigrationGeneratorInterface {
    */
   protected function generateMigrationPlugin(SourcePluginInterface $migration) {
     $migration_plugin = [
-      'id' => $migration->getKey(),
+      'id' => $migration->getId(),
       'migration_tags' => ['migrate_default_content'],
       'label' => $migration->getId(),
       'class' => '\Drupal\migrate\Plugin\Migration',


### PR DESCRIPTION
While migrating the migration generator to a new service, I forgot to refactor this line, so we are creating circular dependencies that break the migration process.
Using the right value solves the problem