### PR TITLE
Avoid notice when running the migration

### DIFF
--- a/src/BaseSourcePlugin.php
+++ b/src/BaseSourcePlugin.php
@@ -100,7 +100,8 @@ class BaseSourcePlugin implements SourcePluginInterface {
    */
   public function getKey() {
     // Assume the key is the first field of the file.
-    return trim(reset($this->getHeader()));
+    $header = $this->getHeader();
+    return trim(reset($header));
   }
 
   /**


### PR DESCRIPTION
I'm getting this notice when trying to run the migration: ( ! ) Notice: Only variables should be passed by reference in /var/www/vtb/web/modules/contrib/migrate_default_content/src/BaseSourcePlugin.php on line 103

I know it's just a notice, but in my current environment it throws an exception.

Best,
Pablo